### PR TITLE
Allow empty prefixes

### DIFF
--- a/src/main/java/me/omegaweapondev/stylizer/utilities/MessageHandler.java
+++ b/src/main/java/me/omegaweapondev/stylizer/utilities/MessageHandler.java
@@ -42,9 +42,8 @@ public class MessageHandler {
   }
 
   public String getPrefix() {
-    if(messagesConfig.getString("Prefix") == null) {
-      getErrorMessage("Prefix");
-      return "#6b6b6b&l[#6928f7Stylizer#6b6b6b&l]" + " ";
+    if(messagesConfig.getString("Prefix") == null || messagesConfig.getString("Prefix") == "") {
+      return "";
     }
     return messagesConfig.getString("Prefix") + " ";
   }


### PR DESCRIPTION
A `null` or `""` prefix should show no prefix.